### PR TITLE
Bugfix/gs segfault fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ missing
 pdf2laser
 src/.deps/*
 stamp-h1
+.DS_Store
+._*
+*~

--- a/src/pdf2laser.c
+++ b/src/pdf2laser.c
@@ -112,7 +112,7 @@ static bool execute_ghostscript(print_job_t *print_job,
 
 	int32_t rc;
 
-	void *minst;
+	void *minst = NULL;
 	rc = gsapi_new_instance(&minst, NULL);
 
 	if (rc < 0)

--- a/src/pdf2laser.c
+++ b/src/pdf2laser.c
@@ -58,7 +58,7 @@
 #include "pdf2laser_vector_list.h"  // for vector_list_t, vector_list_create
 
 FILE *fh_vector;
-static int GSDLLCALL gsdll_stdout(void *minst, const char *str, int len)
+static int GSDLLCALL gsdll_stdout(__attribute__ ((unused)) void *minst, const char *str, int len)
 {
 	size_t rc = fwrite(str, 1, len, fh_vector);
 	fflush(fh_vector);

--- a/src/pdf2laser_generator.c
+++ b/src/pdf2laser_generator.c
@@ -59,7 +59,7 @@ bool generate_ps(const char *target_pdf, const char *target_ps)
 	gs_argv[12] = strndup(target_pdf, 1024);
 
 	int32_t rc;
-	void *minst;
+	void *minst = NULL;
 
 	rc = gsapi_new_instance(&minst, NULL);
 	if (rc < 0)

--- a/src/pdf2laser_generator.c
+++ b/src/pdf2laser_generator.c
@@ -118,7 +118,7 @@ bool generate_eps(print_job_t *print_job, FILE *ps_file, FILE *eps_file)
 				 "and "
 				 "exch 1.0 eq "
 				 "and "
-				 // check for solid blue
+				 // check for solid green
 				 "currentrgbcolor "
 				 "0.0 eq "
 				 "exch 1.0 eq "

--- a/src/pdf2laser_printer.c
+++ b/src/pdf2laser_printer.c
@@ -173,7 +173,7 @@ bool printer_send(const char *host, FILE *pjl_file, const char *job_name)
 		bytes_sent += bs;
 	}
 
-	printf("Job size: %d (%d)\r\n", bytes_sent, count);
+	printf("Job size: %d (%d)\n", bytes_sent, count);
 #else
 	{
 		char buffer[102400];
@@ -181,7 +181,7 @@ bool printer_send(const char *host, FILE *pjl_file, const char *job_name)
 		while ((rc = fread(buffer, 1, 102400, pjl_file)) > 0)
 			write(p_sock, buffer, rc);
 
-		printf("Job size: %d (%d)\r\n", file_stat.st_size);
+		printf("Job size: %d\n", (int)file_stat.st_size);
 	}
 #endif
 

--- a/src/pdf2laser_vector_list.c
+++ b/src/pdf2laser_vector_list.c
@@ -93,8 +93,8 @@ vector_list_t *vector_list_stats(vector_list_t *self)
 		vector = vector->next;
 	}
 
-	printf("Cuts: %d len %ld\n", cuts, cut_total);
-	printf("Move: %d len %ld\n", transits, transit_total);
+	printf("Cuts: %d len %lld\n", cuts, cut_total);
+	printf("Move: %d len %lld\n", transits, transit_total);
 
 	return self;
 }


### PR DESCRIPTION
This pull request fixes a segmentation fault due to uninitialized gsapi instance pointers, which I experience when building pdf2laser with clang under macOS 10.14.6 using support libraries provided by MacPorts. I've also included some minor cleanup fixes:

- Fix segmentation fault due to uninitialized gsapi instance pointers.
- Fix compiler warning for unused function argument.
- Fix compiler warnings for printf format strings.
- Add macOS metadata files and emacs backup files to .gitignore.
- Correct a copy/paste mistake in a comment.


