### PR TITLE
Add multipass vector cutting feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ missing
 pdf2laser
 src/.deps/*
 stamp-h1
+.DS_Store
+._*
+*~

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,10 @@ AM_INIT_AUTOMAKE([-Wall])
 AC_CONFIG_SRCDIR([src/pdf2laser.c])
 AC_CONFIG_HEADERS([config.h])
 
+# Define configurable defaults.
+AC_ARG_VAR([DEFAULT_HOST], [Default host address when -p/--printer is not specified. If not overridden, defaults to the NYC Resistor laser host (192.168.1.4).])
+AC_DEFINE_UNQUOTED([DEFAULT_HOST], ["${DEFAULT_HOST=192.168.1.4}"], [Default host address when -p/--printer is not specified.])
+
 # Checks for programs.
 AC_PROG_CC([clang gcc])
 AC_PROG_INSTALL

--- a/doc/pdf2laser.1
+++ b/doc/pdf2laser.1
@@ -58,7 +58,7 @@ the page so that you do not waste time moving the head over blank space
 between them.
 .PP
 Vector is controlled by the options:
-.IR FREQUENCY ", " POWER ", and " SPEED "."
+.IR FREQUENCY ", " POWER ", " SPEED ", and " PASSES "."
 .PP
 .I FREQUENCY
 controls the duty cycle of the laser. It can be set from values between 10 and
@@ -70,19 +70,23 @@ will produce perforation instead of a continuous cut in thinner materials like
 paper.
 .PP
 The
-.I POWER
-and
+.IR POWER ,
 .I SPEED
+and
+.I PASSES
 settings take between one and three numeric arguments, separated by
 commas (e.g. 20,10). These correspond to the
 .I POWER
 and
 .I SPEED
-levels for the red, green, and blue values of the image. The colours are
+levels for the red, green, and blue values of the image, and the
+number of times to repeat (that is, the
+.I PASSES
+count) the vector cuts corresponding to each color. The colours are
 defined in the same manner as in the colour mode of the raster section
-above. The omitted values will be set to the value preceding it. If you set
-only the red value then green and blue will use that, if you set red and green
-then blue will use the green value.
+above. The omitted values will be set to the value preceding it. If
+you set only the red value then green and blue will use that, if you
+set red and green then blue will use the green value.
 .B DO NOT COUNT ON THIS FUNCTIONALITY, IT WILL CHANGE IN THE FUTURE\fR.
 .
 .SH OPTIONS
@@ -125,12 +129,16 @@ Vector frequency (10-5000).
 Disable vector optimization.
 .TP
 .BI \-V " POWER" "\fR,\fP \-\^\-vector-power=" POWER
-Vector power for the R,G and B passes.
-If only one power or speed is specified it will be used for all three.
+Vector power for the R, G, and B passes.
+If only one power is specified it will be used for all three.
 .TP
 .BI \-v " SPEED" "\fR,\fP \-\^\-vector-speed=" SPEED
-Vector speed for the R,G and B passes.
-If only one power or speed is specified it will be used for all three.
+Vector speed for the R, G, and B passes.
+If only one speed is specified it will be used for all three.
+.TP
+.BI \-M " PASSES" "\fR,\fP \-\^\-multipass=" PASSES
+Number of times to repeat the R, G, and B passes (1 or more).
+If only one pass count is specified it will be used for all three.
 .SS GENERIC OPTIONS
 .TP
 .B \-\^\-help

--- a/src/pdf2laser.c
+++ b/src/pdf2laser.c
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
 	// Report the settings on stdout
 	printf("Job: %s\n"
 		   "Raster: speed=%d power=%d dpi=%d\n"
-		   "Vector: freq=%d speed=%d,%d,%d power=%d,%d,%d\n"
+		   "Vector: freq=%d speed=R%d,G%d,B%d power=R%d,G%d,B%d multipass=R%d,G%d,B%d\n"
 		   "",
 		   print_job->name,
 		   print_job->raster->speed,
@@ -220,7 +220,10 @@ int main(int argc, char *argv[])
 		   print_job->vectors[2]->speed,
 		   print_job->vectors[0]->power,
 		   print_job->vectors[1]->power,
-		   print_job->vectors[2]->power);
+		   print_job->vectors[2]->power,
+		   print_job->vectors[0]->multipass,
+		   print_job->vectors[1]->multipass,
+		   print_job->vectors[2]->multipass);
 
 	char *target_base = strndup(source_basename, FILENAME_NCHARS);
 	char *last_dot = strrchr(target_base, '.');

--- a/src/pdf2laser.c
+++ b/src/pdf2laser.c
@@ -112,7 +112,7 @@ static bool execute_ghostscript(print_job_t *print_job,
 
 	int32_t rc;
 
-	void *minst;
+	void *minst = NULL;
 	rc = gsapi_new_instance(&minst, NULL);
 
 	if (rc < 0)

--- a/src/pdf2laser.c
+++ b/src/pdf2laser.c
@@ -159,8 +159,9 @@ int main(int argc, char *argv[])
 		return false;
 	}
 
-	// This is the NYC Resistor laser host.
-	char *host = "192.168.1.4";
+	// Default host is defined in config.h, and can be overridden at configuration time, e.g.
+	//   ./configure DEFAULT_HOST=foo
+	char *host = DEFAULT_HOST;
 
 	// Job struct defaults
 	print_job_t *print_job = &(print_job_t){

--- a/src/pdf2laser.c
+++ b/src/pdf2laser.c
@@ -58,7 +58,7 @@
 #include "pdf2laser_vector_list.h"  // for vector_list_t, vector_list_create
 
 FILE *fh_vector;
-static int GSDLLCALL gsdll_stdout(void *minst, const char *str, int len)
+static int GSDLLCALL gsdll_stdout(__attribute__ ((unused)) void *minst, const char *str, int len)
 {
 	size_t rc = fwrite(str, 1, len, fh_vector);
 	fflush(fh_vector);

--- a/src/pdf2laser_generator.c
+++ b/src/pdf2laser_generator.c
@@ -59,7 +59,7 @@ bool generate_ps(const char *target_pdf, const char *target_ps)
 	gs_argv[12] = strndup(target_pdf, 1024);
 
 	int32_t rc;
-	void *minst;
+	void *minst = NULL;
 
 	rc = gsapi_new_instance(&minst, NULL);
 	if (rc < 0)

--- a/src/pdf2laser_generator.c
+++ b/src/pdf2laser_generator.c
@@ -118,7 +118,7 @@ bool generate_eps(print_job_t *print_job, FILE *ps_file, FILE *eps_file)
 				 "and "
 				 "exch 1.0 eq "
 				 "and "
-				 // check for solid blue
+				 // check for solid green
 				 "currentrgbcolor "
 				 "0.0 eq "
 				 "exch 1.0 eq "

--- a/src/pdf2laser_printer.c
+++ b/src/pdf2laser_printer.c
@@ -173,7 +173,7 @@ bool printer_send(const char *host, FILE *pjl_file, const char *job_name)
 		bytes_sent += bs;
 	}
 
-	printf("Job size: %d (%d)\r\n", bytes_sent, count);
+	printf("Job size: %d (%d)\n", bytes_sent, count);
 #else
 	{
 		char buffer[102400];
@@ -181,7 +181,7 @@ bool printer_send(const char *host, FILE *pjl_file, const char *job_name)
 		while ((rc = fread(buffer, 1, 102400, pjl_file)) > 0)
 			write(p_sock, buffer, rc);
 
-		printf("Job size: %d (%d)\r\n", file_stat.st_size);
+		printf("Job size: %d\n", (int)file_stat.st_size);
 	}
 #endif
 

--- a/src/pdf2laser_vector_list.c
+++ b/src/pdf2laser_vector_list.c
@@ -12,6 +12,7 @@ vector_list_t *vector_list_create(void)
 	list->pass = 0;
 	list->power = 0;
 	list->speed = 0;
+	list->multipass = 1;
 	return list;
 }
 
@@ -177,6 +178,7 @@ vector_list_t *vector_list_optimize(vector_list_t *self)
 	list->pass = self->pass;
 	list->power = self->power;
 	list->speed = self->speed;
+	list->multipass = self->multipass;
 
 	return list;
 }

--- a/src/pdf2laser_vector_list.c
+++ b/src/pdf2laser_vector_list.c
@@ -93,8 +93,8 @@ vector_list_t *vector_list_stats(vector_list_t *self)
 		vector = vector->next;
 	}
 
-	printf("Cuts: %d len %ld\n", cuts, cut_total);
-	printf("Move: %d len %ld\n", transits, transit_total);
+	printf("Cuts: %d len %lld\n", cuts, cut_total);
+	printf("Move: %d len %lld\n", transits, transit_total);
 
 	return self;
 }

--- a/src/pdf2laser_vector_list.h
+++ b/src/pdf2laser_vector_list.h
@@ -20,6 +20,7 @@ struct vector_list {
 	int32_t pass;
 	int32_t power;
 	int32_t speed;
+	int32_t multipass;
 };
 
 vector_list_t *vector_list_create(void);


### PR DESCRIPTION
This pull request adds new -M/--multipass command line options which allow each
vector pass to be repeated multiple times, e.g. for cutting materials which cut better
with multiple passes at a lower power and/or higher speed. It also fixes some bugs
found during its development.

- Add -M/--multipass flags, specifying number of times to perform the R,G,B vector passes.
- Fix assignments of vector speed and power to correct vector passes.
- Fix overriding of specified R,G,B vector power levels with 100.
